### PR TITLE
Conrad selectively restart chef

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,10 +2,10 @@
 #
 # Licensed under Apache 2.0 - see the LICENSE file
 
-# Select git revision for building druid from source
-default[:druid][:version] = '0.8.0' # Specifies build filename, may need '-SNAPSHOT' or '-rc1' suffix
-default[:druid][:repository] = 'https://github.com/optimizely/druid.git'
-default[:druid][:revision] = '73d42a2a5ca9aa3fadbc9eb072336702551fab18' # Release 0.8.0
+# Select git revision for building druid from source (we can only deploy tagged releases)
+default[:druid][:version] = '0.8.0' # Specifies build filename, may need '-rc1' suffix, etc
+default[:druid][:repository] = 'https://github.com/optimizely/druid.git' # Note this is not the official druid repo
+default[:druid][:revision] = 'druid-' +  default[:druid][:version] # Release 0.8.0
 
 # Installation
 default[:druid][:user] = "druid"

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -149,7 +149,7 @@ action :install do
   # Launch druid using upstart if necessary
   service "druid-#{node_type}" do
     provider Chef::Provider::Service::Upstart
-    supports :restart => true, :start => true, :stop => true, :reload => true
+    supports :restart => true, :start => true, :stop => true, :reload => true, :status => true
     action [:enable, :start]
   end
 end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -122,6 +122,7 @@ action :install do
     variables({:node_type => node_type})
     owner node[:druid][:user]
     group node[:druid][:group]
+    notifies :restart, "service[druid-#{node_type}]", :delayed
   end
 
   # Upstart template to launch and manage druid process
@@ -143,7 +144,7 @@ action :install do
                   :port => type_specific_props["druid.port"],
                   :extra_classpath => (extra_classpath.nil? || extra_classpath.empty?) ? "" : "#{extra_classpath}:"
               })
-    notifies :reload, "service[druid-#{node_type}]", :immediately
+    notifies :restart, "service[druid-#{node_type}]", :delayed
   end
 
   # Launch druid using upstart if necessary

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -152,5 +152,7 @@ action :install do
     provider Chef::Provider::Service::Upstart
     supports :restart => true, :start => true, :stop => true, :reload => true, :status => true
     action [:enable, :start]
+    retries 2
+    retry_delay 2
   end
 end


### PR DESCRIPTION
Here I make a couple changes that should ensure that 'druid is only restarted if something changes.'  In particular, the default recipe no longer restarts druid regardless of what happens.  Druid is only restarted if the configuration is changed or if it is recompiled (due to a version change).
